### PR TITLE
Allow for five tabs without line break

### DIFF
--- a/src/css/vars.css
+++ b/src/css/vars.css
@@ -133,7 +133,7 @@
   --toc-width: calc(162 / var(--rem-base) * 1rem);
   --toc-width--widescreen: calc(216 / var(--rem-base) * 1rem);
   --doc-max-width: calc(720 / var(--rem-base) * 1rem);
-  --doc-max-width--desktop: calc(828 / var(--rem-base) * 1rem);
+  --doc-max-width--desktop: calc(1080 / var(--rem-base) * 1rem);
   /* stacking */
   --z-index-nav: 1;
   --z-index-toolbar: 2;


### PR DESCRIPTION
We need to build and package it the UI into a new release.
Current solution patterns (and the template) are pulling their CSS in the site.yml playbook
```
ui:
  bundle:
    url: https://github.com/redhat-solution-patterns/course-ui/releases/download/v0.1.13-custom/ui-bundle.zip
``` 

This PR has a small change allowing for a slightly wider max-width, not breaking the tabs into two rows.

![image](https://user-images.githubusercontent.com/33287465/206922419-37699baf-b6e9-4f9e-bae8-25d34de34210.png)

